### PR TITLE
[RFC] atf: optee: compile ATF with OP-TEE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "burn-boot"]
 	path = burn-boot
 	url = https://github.com/96boards/burn-boot.git
+[submodule "optee_os"]
+	path = optee_os
+	url = https://github.com/OP-TEE/optee_os.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
 # Install the cross-compiler
 before_install:
   - sudo apt-get update -qq
+  - sudo apt-get install python-crypto python-wand
   # Travis does 'export CC=gcc'. Unset CC so that ./flags.mk properly
   # defines the cross-compiler to the default value: $(CROSS_COMPILE)gcc.
   - unset CC

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,12 @@ u-boot-clean:
 # ARM Trusted Firmware
 ################################################################################
 .PHONY: arm-tf
-arm-tf: u-boot optee-os
+arm-tf: u-boot optee-os mcuimage
 	$(MAKE) -C $(ARM_TF_PATH) CROSS_COMPILE="$(CCACHE)$(AARCH64_CROSS_COMPILE)" all fip \
 		BL30=$(MCU_BIN) \
 		BL33=$(UBOOT_BIN) \
 		DEBUG=1 \
+		DISABLE_PEDANTIC=1 \
 		BL32=$(OPTEE_BIN) \
 		PLAT=hikey SPD=opteed
 


### PR DESCRIPTION
As atf version, which is used in the current setup, doesn't support v2 headers
of OP-TEE BLOBs, 2.3.0 version is used.

Also added a workaround for fixing fip.bin aligment issues, when it's flashed
via fastboot.

Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>